### PR TITLE
Renamed data property to prevent overriding

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ Event::on(
     \ether\mc\services\ProductsService::EVENT_AFTER_BUILD_SYNC_DATA,
     function (\ether\mc\events\BuildSyncDataEvent $event) {
         $event->element; // The element being synced
-        $event->data; // The resulting data to sync
+        $event->syncdata; // The resulting data to sync
 
         // For example, to modify the product description
-        $event->data->description = $event->element->alternateDescriptionField;
+        $event->syncdata->description = $event->element->alternateDescriptionField;
     }
 );
 ```

--- a/src/events/BuildSyncDataEvent.php
+++ b/src/events/BuildSyncDataEvent.php
@@ -24,6 +24,6 @@ class BuildSyncDataEvent extends Event
 	public $element;
 
 	/** @var array */
-	public $data;
+	public $syncdata;
 
 }

--- a/src/services/ProductsService.php
+++ b/src/services/ProductsService.php
@@ -46,7 +46,7 @@ class ProductsService extends Component
 	 *     \ether\mc\services\ProductsService::EVENT_AFTER_BUILD_SYNC_DATA,
 	 *     function (\ether\mc\events\BuildSyncDataEvent $event) {
 	 *         $event->element; // The element being synced
-	 *         $event->data; // The resulting data to sync
+	 *         $event->syncdata; // The resulting data to sync
 	 *     }
 	 * );
 	 */
@@ -348,11 +348,11 @@ class ProductsService extends Component
 
 		$event = new BuildSyncDataEvent([
 			'element' => $product,
-			'data' => $data,
+			'syncdata' => $data,
 		]);
 		$this->trigger(self::EVENT_AFTER_BUILD_SYNC_DATA, $event);
 
-		return $event->data;
+		return $event->syncdata;
 	}
 
 	/**


### PR DESCRIPTION
We tracked down a bug where `data` was NULL when we tried to sync all the products. When renaming the data property to something else, it worked. So I guess the property got overridden by something else?