### PR TITLE
Update PromosService.php

### DIFF
--- a/src/services/PromosService.php
+++ b/src/services/PromosService.php
@@ -268,7 +268,7 @@ class PromosService extends Component
 			'amount' => (float) $amount,
 			'type' => $type,
 			'target' => $target,
-			'enabled' => $promo->enabled,
+			'enabled' => (int)$promo->enabled == 1 ? true : false,
 			'created_at_foreign' => $promo->dateCreated->format('c'),
 			'updated_at_foreign' => $promo->dateUpdated->format('c'),
 		];


### PR DESCRIPTION
Fixes issue syncing promos. Mailchimp API requires a Boolean value for 'enabled'. The value returned by Commerce is not interpreted as Boolean.