### PR TITLE
Support Guzzle 7: Fixes #43 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "require": {
     "craftcms/cms": "^3.1.0",
     "craftcms/commerce": "^3.0.0",
-    "guzzlehttp/guzzle": "^6.3.3",
+    "guzzlehttp/guzzle": "^6.3.3|^7.3",
     "ext-json": "*"
   },
   "autoload": {


### PR DESCRIPTION
When Guzzle 7 is used in the Craft project it is currently not possible to install the Plugin. And supporting Guzzle 7 doesn't seem to break the synchronization.

Fixes #43 